### PR TITLE
Multinotas

### DIFF
--- a/src/Ekreative/HealthCheckBundle/Controller/HealthCheckController.php
+++ b/src/Ekreative/HealthCheckBundle/Controller/HealthCheckController.php
@@ -167,17 +167,21 @@ class HealthCheckController
         {
             try {
                 $client = new Client();
-                
-                $url = $rabbitmq['host'].':'.$rabbitmq['port']. '/api/healthchecks/node';
-                
-                $response = $client->request('GET',$url, 
-                    ['auth' => [$rabbitmq['user'], $rabbitmq['password']]]);
 
-                if($response->getStatusCode() == 200){
-                    return true;
-                }else{
-                    return false;
+                $tentativa = 5;
+
+                while($tentativa--){
+                    $url = $rabbitmq['host'].':'.$rabbitmq['port']. '/api/healthchecks/node';
+
+                    $response = $client->request('GET', $url, [
+                        'auth' => [$rabbitmq['user'], $rabbitmq['password']],'timeout' => 3,
+                    ]);
+
+                    if($response->getStatusCode() == 200){
+                        return true;
+                    }
                 }
+                return false;
             } catch (\Exception $e) {
                 return false;
             }

--- a/src/Ekreative/HealthCheckBundle/Controller/HealthCheckController.php
+++ b/src/Ekreative/HealthCheckBundle/Controller/HealthCheckController.php
@@ -168,7 +168,7 @@ class HealthCheckController
             try {
                 $client = new Client();
                 
-                $url = $rabbitmq['host'] .':'.$rabbitmq['port']. '/api/healthchecks/node';
+                $url = $rabbitmq['host'].':'.$rabbitmq['port']. '/api/healthchecks/node';
                 
                 $response = $client->request('GET',$url, 
                     ['auth' => [$rabbitmq['user'], $rabbitmq['password']]]);


### PR DESCRIPTION
Atualização referente ao Multinotas - checagem do RabbitMQ.
Em algumas consultas ao RabbitMQ via HTTP não responde até o timeout. Porem na próxima requisição responde normalmente.
O timeout foi ajustado para 3 segundo que é tempo suficiente para uma resposta.
foi configurado 5 tentativas antes de retornar o falso para pular os falsos negativos.